### PR TITLE
Bump to upstream version 1.8.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGETARCH
 ARG SRC=github.com/kubernetes/autoscaler
 ARG PKG=github.com/kubernetes/autoscaler
 RUN git clone https://${SRC}.git $GOPATH/src/${PKG}
-ARG TAG=1.8.20
+ARG TAG=1.8.22
 WORKDIR $GOPATH/src/${PKG}/addon-resizer
 RUN git branch -a
 RUN git checkout addon-resizer-${TAG} -b ${TAG}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TAG ?= ${GITHUB_ACTION_TAG}
 export DOCKER_BUILDKIT?=1
 
 ifeq ($(TAG),)
-TAG := 1.8.20$(BUILD_META)
+TAG := 1.8.22$(BUILD_META)
 endif
 
 REPO ?= rancher


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version 1.8.22</summary>
            <p>changed lines [17] of file &#34;/tmp/updatecli/github/mgfritch/image-build-addon-resizer/Dockerfile&#34;</p>
            <details>
                <summary>1.8.22</summary>
                <pre>&#xA;Release published on the 2024-06-19 15:59:43 +0000 UTC at the url https://github.com/kubernetes/autoscaler/releases/tag/addon-resizer-1.8.22&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;- Various dependency bumps&#xD;&#xA;- Added a Prometheus endpoint for monitoring to addon-resizer by @raywainman in https://github.com/kubernetes/autoscaler/pull/6916&#xD;&#xA;&#xD;&#xA;**Full Changelog:** https://github.com/kubernetes/autoscaler/compare/addon-resizer-1.8.21...addon-resizer-1.8.22</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version 1.8.22</summary>
            <p>1 file(s) updated with &#34;TAG := 1.8.22$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

